### PR TITLE
Enhance planner functionality and requirement tracking

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,20 +7,30 @@ import {
   AppBar,
   Toolbar,
   Typography,
-  Button,
+  Tabs,
+  Tab,
   IconButton,
+  Avatar,
   Box,
+  Container,
+  Paper,
+  Stack,
+  Tooltip,
+  Divider,
 } from "@mui/material";
 import {
   LightMode as LightModeIcon,
   DarkMode as DarkModeIcon,
   Logout as LogoutIcon,
+  LibraryBooks as LibraryBooksIcon,
+  EventNote as EventNoteIcon,
 } from "@mui/icons-material";
 
 import { fetchCourses } from "./api/fetchCourses";
 import CourseCatalog from "./components/CourseCatalog";
 import Planner from "./components/Planner";
 import Login from "./components/Login";
+import defaultProgramPlan from "./data/comp_math_plan.json";
 
 function App() {
   const [user, setUser] = useState(null);
@@ -28,11 +38,59 @@ function App() {
   const [plan, setPlan] = useState([]);
   const [view, setView] = useState("catalog");
   const [darkMode, setDarkMode] = useState(false);
+  const [programPlan, setProgramPlan] = useState(() =>
+    JSON.parse(JSON.stringify(defaultProgramPlan))
+  );
 
   const theme = useMemo(
     () =>
       createTheme({
-        palette: { mode: darkMode ? "dark" : "light" },
+        palette: {
+          mode: darkMode ? "dark" : "light",
+          primary: {
+            main: darkMode ? "#90caf9" : "#005daa",
+          },
+          secondary: {
+            main: darkMode ? "#f48fb1" : "#ffb800",
+          },
+          background: {
+            default: darkMode ? "#0f172a" : "#f5f7fb",
+            paper: darkMode ? "#111827" : "#ffffff",
+          },
+        },
+        shape: {
+          borderRadius: 16,
+        },
+        typography: {
+          fontFamily: "'Inter', 'Segoe UI', sans-serif",
+        },
+        components: {
+          MuiPaper: {
+            styleOverrides: {
+              root: {
+                transition: "box-shadow 0.3s ease, transform 0.3s ease",
+              },
+            },
+          },
+          MuiButton: {
+            styleOverrides: {
+              root: {
+                borderRadius: 999,
+                textTransform: "none",
+                fontWeight: 600,
+              },
+            },
+          },
+          MuiTab: {
+            styleOverrides: {
+              root: {
+                textTransform: "none",
+                fontWeight: 600,
+                minHeight: 0,
+              },
+            },
+          },
+        },
       }),
     [darkMode]
   );
@@ -105,6 +163,28 @@ function App() {
       });
   };
 
+  const updateCourseTerm = (code, term) => {
+    supabase
+      .from("user_courses")
+      .update({ term })
+      .eq("user_id", user.id)
+      .eq("course_code", code)
+      .select()
+      .then(({ data, error }) => {
+        if (error) {
+          console.error("Update term error:", error);
+          return;
+        }
+        if (!data?.length) return;
+        const updated = data[0];
+        setPlan((prev) =>
+          prev.map((entry) =>
+            entry.course_code === code ? { ...entry, term: updated.term } : entry
+          )
+        );
+      });
+  };
+
   const toggleComplete = (code) => {
     const entry = plan.find((p) => p.course_code === code);
     if (!entry) return;
@@ -131,78 +211,160 @@ function App() {
       .split(".")
       .map((w) => w[0].toUpperCase() + w.slice(1))
       .join(" ");
-  const tabSx = (viewName) => ({
-    textTransform: "none",
-    whiteSpace: "nowrap",
-    px: 2,
-    color: view === viewName ? "primary.main" : "common.white",
-    bgcolor: view === viewName ? "common.white" : "transparent",
-    borderRadius: 1,
-    fontWeight: view === viewName ? "bold" : "normal",
-    "&:hover": {
-      bgcolor: view === viewName ? "common.white" : "rgba(255,255,255,0.2)",
-    },
-  });
-
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppBar position="sticky">
-        <Toolbar>
-          <Box
-            sx={{ display: "flex", alignItems: "center", gap: 3, mr: "auto" }}
-          >
-            <Box
-              component="img"
-              src={`${process.env.PUBLIC_URL}/uwlogo.svg`}
-              alt="UW Logo"
-              sx={{ height: 38 }}
-            />
-            <Button
-              sx={{ ...tabSx("catalog"), minWidth: 140 }}
-              onClick={() => setView("catalog")}
-            >
-              Course Catalog
-            </Button>
-            <Button
-              sx={{ ...tabSx("planner"), minWidth: 100 }}
-              onClick={() => setView("planner")}
-            >
-              Planner
-            </Button>
-          </Box>
-          <Typography sx={{ color: "common.white", mr: 1 }}>
-            Hello, {displayName}
-          </Typography>
-          <IconButton color="inherit" onClick={handleLogout}>
-            <LogoutIcon />
-          </IconButton>
-          <IconButton
-            color="inherit"
-            onClick={() => setDarkMode((d) => !d)}
-            sx={{ ml: 1 }}
-          >
-            {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+      <Box
+        sx={{
+          minHeight: "100vh",
+          background: (theme) =>
+            theme.palette.mode === "light"
+              ? "radial-gradient(circle at top left, rgba(0,93,170,0.12), transparent 55%), radial-gradient(circle at bottom right, rgba(255,184,0,0.12), transparent 40%)"
+              : "radial-gradient(circle at top left, rgba(144,202,249,0.12), transparent 55%), radial-gradient(circle at bottom right, rgba(244,143,177,0.12), transparent 40%)",
+        }}
+      >
+        <AppBar
+          position="sticky"
+          elevation={0}
+          sx={{
+            background: (theme) =>
+              theme.palette.mode === "light"
+                ? "linear-gradient(90deg, #002f6c, #005daa)"
+                : "linear-gradient(90deg, #0f172a, #1f2937)",
+            borderBottom: (theme) =>
+              `1px solid ${theme.palette.mode === "light" ? "rgba(255,255,255,0.25)" : "rgba(148, 163, 184, 0.16)"}`,
+          }}
+        >
+          <Toolbar sx={{ gap: 3 }}>
+            <Stack direction="row" alignItems="center" spacing={2} sx={{ mr: "auto" }}>
+              <Avatar
+                src={`${process.env.PUBLIC_URL}/uwlogo.svg`}
+                alt="UW Logo"
+                sx={{ width: 40, height: 40, bgcolor: "transparent" }}
+                variant="rounded"
+              />
+              <Box>
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  UW Course Planner
+                </Typography>
+                <Typography variant="caption" sx={{ opacity: 0.85 }}>
+                  Design a personalized academic path
+                </Typography>
+              </Box>
+            </Stack>
 
-      <Box sx={{ p: 2, height: "calc(100vh - 64px)", overflow: "auto" }}>
-        {view === "catalog" ? (
-          <CourseCatalog
-            courses={courses}
-            planCodes={planCodes}
-            onAddCourse={addCourse}
-            onRemoveCourse={removeCourse}
-          />
-        ) : (
-          <Planner
-            plan={plan}
-            coursesMap={coursesMap}
-            onRemoveCourse={removeCourse}
-            onToggleComplete={toggleComplete}
-          />
-        )}
+            <Tabs
+              value={view}
+              onChange={(_, newValue) => setView(newValue)}
+              textColor="inherit"
+              TabIndicatorProps={{
+                sx: {
+                  height: 3,
+                  borderRadius: 2,
+                  backgroundColor: "secondary.main",
+                },
+              }}
+              sx={{
+                minHeight: 0,
+                "& .MuiTab-root": {
+                  color: "rgba(255,255,255,0.72)",
+                  minHeight: 0,
+                  paddingX: 2.5,
+                  paddingY: 1,
+                },
+                "& .Mui-selected": {
+                  color: "#fff",
+                },
+              }}
+            >
+              <Tab
+                value="catalog"
+                icon={<LibraryBooksIcon fontSize="small" />}
+                iconPosition="start"
+                label="Catalog"
+              />
+              <Tab
+                value="planner"
+                icon={<EventNoteIcon fontSize="small" />}
+                iconPosition="start"
+                label="Planner"
+              />
+            </Tabs>
+
+            <Divider orientation="vertical" flexItem sx={{ borderColor: "rgba(255,255,255,0.24)" }} />
+
+            <Stack direction="row" spacing={1.5} alignItems="center">
+              <Box textAlign="right">
+                <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.92)" }}>
+                  {displayName}
+                </Typography>
+                <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.7)" }}>
+                  Signed in
+                </Typography>
+              </Box>
+              <Tooltip title="Sign out">
+                <IconButton color="inherit" onClick={handleLogout}>
+                  <LogoutIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={darkMode ? "Switch to light mode" : "Switch to dark mode"}>
+                <IconButton
+                  color="inherit"
+                  onClick={() => setDarkMode((d) => !d)}
+                >
+                  {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+                </IconButton>
+              </Tooltip>
+            </Stack>
+          </Toolbar>
+        </AppBar>
+
+        <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 } }}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: { xs: 2.5, md: 4 },
+              borderRadius: 4,
+              backgroundColor: (theme) =>
+                theme.palette.mode === "light"
+                  ? "rgba(255,255,255,0.92)"
+                  : "rgba(17,24,39,0.9)",
+              border: (theme) =>
+                `1px solid ${
+                  theme.palette.mode === "light"
+                    ? "rgba(148, 163, 184, 0.32)"
+                    : "rgba(148, 163, 184, 0.24)"
+                }`,
+              boxShadow: (theme) =>
+                theme.palette.mode === "light"
+                  ? "0px 18px 40px rgba(15, 23, 42, 0.08)"
+                  : "0px 18px 40px rgba(0, 0, 0, 0.55)",
+            }}
+          >
+            {view === "catalog" ? (
+              <CourseCatalog
+                courses={courses}
+                planCodes={planCodes}
+                onAddCourse={addCourse}
+                onRemoveCourse={removeCourse}
+                programPlan={programPlan}
+                onProgramPlanChange={setProgramPlan}
+                onProgramPlanReset={() =>
+                  setProgramPlan(JSON.parse(JSON.stringify(defaultProgramPlan)))
+                }
+              />
+            ) : (
+              <Planner
+                plan={plan}
+                coursesMap={coursesMap}
+                onRemoveCourse={removeCourse}
+                onToggleComplete={toggleComplete}
+                onUpdateCourseTerm={updateCourseTerm}
+                programPlan={programPlan}
+              />
+            )}
+          </Paper>
+        </Container>
       </Box>
     </ThemeProvider>
   );

--- a/client/src/components/CourseCatalog.js
+++ b/client/src/components/CourseCatalog.js
@@ -1,5 +1,10 @@
-import React, { useState, useMemo, useEffect } from "react";
-import compMathPlan from "../data/comp_math_plan.json";
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useCallback,
+  useRef,
+} from "react";
 import {
   Box,
   TextField,
@@ -18,26 +23,30 @@ import {
   Button,
   Typography,
   IconButton,
+  Stack,
+  Paper,
+  Alert,
+  Tooltip,
 } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import debounce from "lodash.debounce";
-import { Info as InfoIcon, Close as CloseIcon } from "@mui/icons-material";
+import {
+  Info as InfoIcon,
+  Close as CloseIcon,
+  Upload as UploadIcon,
+  RestartAlt as RestartAltIcon,
+  CheckCircle as CheckCircleIcon,
+} from "@mui/icons-material";
 
 const termOptions = ["1A", "1B", "2A", "2B", "3A", "3B", "4A", "4B"];
-const relevantSubjects = new Set([
-  "MATH",
-  "AMATH",
-  "CO",
-  "CS",
-  "PMATH",
-  "STAT",
-]);
-
 export default function CourseCatalog({
   courses,
   planCodes,
   onAddCourse,
   onRemoveCourse,
+  programPlan,
+  onProgramPlanChange,
+  onProgramPlanReset,
 }) {
   const [rawSearch, setRawSearch] = useState("");
   const [search, setSearch] = useState("");
@@ -46,6 +55,8 @@ export default function CourseCatalog({
   const [subjects, setSubjects] = useState([]);
   const [dialogCourse, setDialogCourse] = useState(null);
   const [dialogTerm, setDialogTerm] = useState(termOptions[0]);
+  const [uploadError, setUploadError] = useState(null);
+  const fileInputRef = useRef(null);
 
   const debouncedSetSearch = useMemo(
     () => debounce((val) => setSearch(val), 300),
@@ -57,11 +68,11 @@ export default function CourseCatalog({
 
   const requiredSet = useMemo(() => {
     const s = new Set();
-    compMathPlan.requirements.forEach((r) =>
-      r.options.forEach((code) => s.add(code))
-    );
+    (programPlan?.requirements || []).forEach((group) => {
+      (group?.options || []).forEach((code) => s.add(code));
+    });
     return s;
-  }, []);
+  }, [programPlan]);
 
   const allSubjects = useMemo(
     () => Array.from(new Set(courses.map((c) => c.subjectCode))).sort(),
@@ -73,12 +84,7 @@ export default function CourseCatalog({
       courses
         .filter((c) => {
           const key = c.subjectCode + c.catalogNumber;
-          if (
-            programOnly &&
-            !requiredSet.has(key) &&
-            !relevantSubjects.has(c.subjectCode)
-          )
-            return false;
+          if (programOnly && !requiredSet.has(key)) return false;
           if (requiredOnly && !requiredSet.has(key)) return false;
           if (subjects.length && !subjects.includes(c.subjectCode))
             return false;
@@ -87,7 +93,10 @@ export default function CourseCatalog({
             const codeStr = `${c.subjectCode} ${c.catalogNumber}`.toLowerCase();
             if (
               !codeStr.includes(q) &&
-              !c.title.toLowerCase().includes(q)
+              !c.title.toLowerCase().includes(q) &&
+              !(c.requirementsDescription || "")
+                .toLowerCase()
+                .includes(q)
             )
               return false;
           }
@@ -111,6 +120,18 @@ export default function CourseCatalog({
       headerName: "Prerequisites",
       flex: 1,
       minWidth: 200,
+    },
+    {
+      field: "required",
+      headerName: "Program fit",
+      width: 150,
+      sortable: false,
+      renderCell: (params) =>
+        requiredSet.has(params.row.id) ? (
+          <Chip size="small" color="secondary" label="Required" />
+        ) : (
+          <Chip size="small" variant="outlined" label="Elective" />
+        ),
     },
     {
       field: "action",
@@ -160,66 +181,193 @@ export default function CourseCatalog({
     closeInfo();
   }
 
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileUpload = useCallback(
+    (event) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(reader.result);
+          if (!Array.isArray(parsed?.requirements)) {
+            throw new Error(
+              "Invalid format: expected a `requirements` array in the JSON file."
+            );
+          }
+          setUploadError(null);
+          onProgramPlanChange(parsed);
+        } catch (error) {
+          console.error("Program upload error", error);
+          setUploadError(error.message || "Unable to parse JSON file.");
+        }
+      };
+      reader.onerror = () => {
+        setUploadError("Unable to read the selected file.");
+      };
+      reader.readAsText(file);
+      event.target.value = "";
+    },
+    [onProgramPlanChange]
+  );
+
+  const programName = programPlan?.programName || "Program requirements";
+  const requirementGroups = programPlan?.requirements || [];
+  const totalRequirementCount = requirementGroups.length;
+  const flattenedRequirementCount = requiredSet.size;
+
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", height: "100%", p: 2 }}>
-      <Box
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Paper
+        variant="outlined"
         sx={{
-          display: "flex",
-          flexWrap: "wrap",
-          gap: 2,
-          mb: 2,
-          alignItems: "center",
+          p: { xs: 2, md: 3 },
+          borderRadius: 3,
+          background: (theme) =>
+            theme.palette.mode === "light"
+              ? "linear-gradient(135deg, rgba(0,93,170,0.08), rgba(0,93,170,0))"
+              : "linear-gradient(135deg, rgba(144,202,249,0.15), rgba(17,24,39,0.6))",
         }}
       >
-        <TextField
-          label="Search courses"
-          size="small"
-          value={rawSearch}
-          onChange={(e) => setRawSearch(e.target.value)}
-          sx={{ minWidth: 200, flexGrow: 1 }}
-        />
-        <FormControl sx={{ minWidth: 180 }} size="small">
-          <InputLabel>Subject</InputLabel>
-          <Select
-            multiple
-            value={subjects}
-            onChange={(e) => setSubjects(e.target.value)}
-            input={<OutlinedInput label="Subject" />}
-            renderValue={(sel) => (
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                {sel.map((s) => (
-                  <Chip key={s} label={s} size="small" />
-                ))}
-              </Box>
-            )}
+        <Stack spacing={2}>
+          <Stack
+            direction={{ xs: "column", md: "row" }}
+            spacing={2.5}
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", md: "center" }}
           >
-            {allSubjects.map((sub) => (
-              <MenuItem key={sub} value={sub}>
-                <Checkbox checked={subjects.includes(sub)} />{" "}
-                <Typography>{sub}</Typography>
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={programOnly}
-              onChange={(e) => setProgramOnly(e.target.checked)}
+            <Box>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                {programName}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Upload a JSON file with your specialized program requirements to
+                tailor the catalog and planner experience.
+              </Typography>
+            </Box>
+
+            <Stack direction="row" spacing={1}>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json"
+                hidden
+                onChange={handleFileUpload}
+              />
+              <Tooltip title="Import a JSON plan exported by your program advisor">
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={<UploadIcon />}
+                  onClick={handleUploadClick}
+                >
+                  Upload plan
+                </Button>
+              </Tooltip>
+              <Tooltip title="Restore the default Computational Mathematics plan">
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={<RestartAltIcon />}
+                  onClick={() => {
+                    setUploadError(null);
+                    onProgramPlanReset();
+                  }}
+                >
+                  Reset
+                </Button>
+              </Tooltip>
+            </Stack>
+          </Stack>
+
+          {uploadError && <Alert severity="error">{uploadError}</Alert>}
+
+          <Stack direction="row" spacing={2} flexWrap="wrap">
+            <Chip
+              icon={<CheckCircleIcon />}
+              color="primary"
+              label={`${totalRequirementCount} requirement group${
+                totalRequirementCount === 1 ? "" : "s"
+              }`}
             />
-          }
-          label="Program only"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={requiredOnly}
-              onChange={(e) => setRequiredOnly(e.target.checked)}
+            <Chip
+              variant="outlined"
+              color="primary"
+              label={`${flattenedRequirementCount} individual course${
+                flattenedRequirementCount === 1 ? "" : "s"
+              } tracked`}
             />
-          }
-          label="Required only"
-        />
-      </Box>
+            {programPlan?.cohort && (
+              <Chip
+                variant="outlined"
+                color="secondary"
+                label={`Cohort: ${programPlan.cohort}`}
+              />
+            )}
+          </Stack>
+        </Stack>
+      </Paper>
+
+      <Paper variant="outlined" sx={{ p: { xs: 2, md: 3 }, borderRadius: 3 }}>
+        <Stack
+          direction={{ xs: "column", lg: "row" }}
+          spacing={2}
+          alignItems={{ xs: "stretch", lg: "center" }}
+          flexWrap="wrap"
+        >
+          <TextField
+            label="Search courses"
+            size="small"
+            value={rawSearch}
+            onChange={(e) => setRawSearch(e.target.value)}
+            sx={{ minWidth: { xs: "100%", sm: 220 }, flexGrow: 1 }}
+          />
+          <FormControl sx={{ minWidth: 200 }} size="small">
+            <InputLabel>Subject</InputLabel>
+            <Select
+              multiple
+              value={subjects}
+              onChange={(e) => setSubjects(e.target.value)}
+              input={<OutlinedInput label="Subject" />}
+              renderValue={(sel) => (
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                  {sel.map((s) => (
+                    <Chip key={s} label={s} size="small" />
+                  ))}
+                </Box>
+              )}
+            >
+              {allSubjects.map((sub) => (
+                <MenuItem key={sub} value={sub}>
+                  <Checkbox checked={subjects.includes(sub)} />
+                  <Typography sx={{ ml: 1 }}>{sub}</Typography>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={programOnly}
+                onChange={(e) => setProgramOnly(e.target.checked)}
+              />
+            }
+            label="Show program matches"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={requiredOnly}
+                onChange={(e) => setRequiredOnly(e.target.checked)}
+              />
+            }
+            label="Only required courses"
+          />
+        </Stack>
+      </Paper>
 
       <Box sx={{ flex: 1 }}>
         <DataGrid
@@ -229,13 +377,36 @@ export default function CourseCatalog({
           rowsPerPageOptions={[25, 50, 100]}
           disableSelectionOnClick
           autoHeight
+          sx={{
+            bgcolor: "transparent",
+            border: 0,
+            "& .MuiDataGrid-columnHeaders": {
+              borderRadius: 0,
+              backgroundColor: (theme) =>
+                theme.palette.mode === "light"
+                  ? "rgba(226, 232, 240, 0.6)"
+                  : "rgba(30, 41, 59, 0.7)",
+            },
+            "& .MuiDataGrid-cell": {
+              borderColor: (theme) =>
+                theme.palette.mode === "light"
+                  ? "rgba(148, 163, 184, 0.3)"
+                  : "rgba(71, 85, 105, 0.5)",
+            },
+            "& .MuiDataGrid-row:hover": {
+              bgcolor: (theme) =>
+                theme.palette.mode === "light"
+                  ? "rgba(0,93,170,0.06)"
+                  : "rgba(148, 197, 239, 0.12)",
+            },
+          }}
         />
       </Box>
 
       {dialogCourse && (
         <Dialog open onClose={closeInfo} fullWidth maxWidth="md">
           <DialogTitle>
-            {dialogCourse.subjectCode} {dialogCourse.catalogNumber} —{" "}
+            {dialogCourse.subjectCode} {dialogCourse.catalogNumber} — {" "}
             {dialogCourse.title}
             <IconButton
               onClick={closeInfo}
@@ -251,7 +422,16 @@ export default function CourseCatalog({
             <Typography variant="body2" paragraph>
               {dialogCourse.description || "None"}
             </Typography>
-            {/* Additional fields... */}
+            {dialogCourse.requirementsDescription && (
+              <>
+                <Typography variant="subtitle1" gutterBottom>
+                  Prerequisites
+                </Typography>
+                <Typography variant="body2" paragraph>
+                  {dialogCourse.requirementsDescription}
+                </Typography>
+              </>
+            )}
             <Box mt={3}>
               <TextField
                 select
@@ -287,5 +467,5 @@ export default function CourseCatalog({
         </Dialog>
       )}
     </Box>
-);
+  );
 }

--- a/client/src/components/Planner.js
+++ b/client/src/components/Planner.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import {
   Box,
   TextField,
@@ -7,52 +7,78 @@ import {
   Select,
   OutlinedInput,
   MenuItem,
-  Checkbox as MuiCheckbox,
   Chip,
-  TableContainer,
-  Paper,
-  Table,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableBody,
   Checkbox,
+  Stack,
+  Paper,
+  Typography,
   IconButton,
-  TableSortLabel,
+  Tooltip,
+  Divider,
+  Button,
+  LinearProgress,
   Dialog,
   DialogTitle,
   DialogContent,
   DialogActions,
-  Button,
-  Typography,
+  Alert,
 } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import InfoIcon from "@mui/icons-material/Info";
-import CloseIcon from "@mui/icons-material/Close";
+import {
+  Delete as DeleteIcon,
+  Info as InfoIcon,
+  CheckCircle as CheckCircleIcon,
+  RadioButtonUnchecked as RadioButtonUncheckedIcon,
+  Download as DownloadIcon,
+} from "@mui/icons-material";
+
+const termOrder = ["1A", "1B", "2A", "2B", "3A", "3B", "4A", "4B"];
+const fallbackTerm = "Unassigned";
+const termOptions = [...termOrder, fallbackTerm];
+
+const requirementStatusConfig = {
+  complete: { label: "Satisfied", color: "success" },
+  "in-progress": { label: "Planned", color: "info" },
+  missing: { label: "Not planned", color: "warning" },
+};
 
 export default function Planner({
   plan,
   coursesMap,
   onRemoveCourse,
   onToggleComplete,
+  onUpdateCourseTerm,
+  programPlan,
 }) {
   const [search, setSearch] = useState("");
   const [subjects, setSubjects] = useState([]);
-  const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
+  const [statusFilter, setStatusFilter] = useState("all");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedCode, setSelectedCode] = useState(null);
 
   const allSubjects = useMemo(() => {
-    const setSub = new Set();
-    plan.forEach((item) => setSub.add(item.course_code.match(/^[A-Za-z]+/)[0]));
-    return Array.from(setSub).sort();
+    const set = new Set();
+    plan.forEach((item) => {
+      const match = item.course_code.match(/^[A-Za-z]+/);
+      if (match) set.add(match[0]);
+    });
+    return Array.from(set).sort();
   }, [plan]);
 
-  const filtered = useMemo(() => {
+  const requiredSet = useMemo(() => {
+    const s = new Set();
+    (programPlan?.requirements || []).forEach((group) => {
+      (group?.options || []).forEach((code) => s.add(code));
+    });
+    return s;
+  }, [programPlan]);
+
+  const filteredPlan = useMemo(() => {
     const q = search.trim().toLowerCase();
     return plan.filter((item) => {
-      const subj = item.course_code.match(/^[A-Za-z]+/)[0];
-      if (subjects.length && !subjects.includes(subj)) return false;
+      const subject = item.course_code.match(/^[A-Za-z]+/)[0];
+      if (subjects.length && !subjects.includes(subject)) return false;
+      if (statusFilter === "complete" && !item.completed) return false;
+      if (statusFilter === "incomplete" && item.completed) return false;
       if (q) {
         const code = item.course_code.toLowerCase();
         const title = (coursesMap[item.course_code]?.title || "").toLowerCase();
@@ -60,172 +86,613 @@ export default function Planner({
       }
       return true;
     });
-  }, [plan, search, subjects, coursesMap]);
+  }, [plan, search, subjects, statusFilter, coursesMap]);
 
-  const sorted = useMemo(() => {
-    if (!sortConfig.key) return filtered;
-    return [...filtered].sort((a, b) => {
-      let av, bv;
-      switch (sortConfig.key) {
-        case "code":
-          av = a.course_code;
-          bv = b.course_code;
-          break;
-        case "title":
-          av = coursesMap[a.course_code]?.title || "";
-          bv = coursesMap[b.course_code]?.title || "";
-          break;
-        case "term":
-          av = a.term;
-          bv = b.term;
-          break;
-        case "completed":
-          av = a.completed ? 1 : 0;
-          bv = b.completed ? 1 : 0;
-          break;
-        default:
-          av = "";
-          bv = "";
+  const progress = useMemo(() => {
+    const total = plan.length;
+    const completed = plan.filter((item) => item.completed).length;
+    const planned = plan.filter((item) => !item.completed).length;
+    const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
+    return { total, completed, planned, percentage };
+  }, [plan]);
+
+  const groupedPlan = useMemo(() => {
+    const groups = new Map();
+    filteredPlan.forEach((item) => {
+      const term = item.term || fallbackTerm;
+      if (!groups.has(term)) {
+        groups.set(term, []);
       }
-      if (av < bv) return sortConfig.direction === "asc" ? -1 : 1;
-      if (av > bv) return sortConfig.direction === "asc" ? 1 : -1;
-      return 0;
+      groups.get(term).push(item);
     });
-  }, [filtered, sortConfig, coursesMap]);
-
-  const handleSort = (key) => {
-    setSortConfig((prev) =>
-      prev.key === key
-        ? { key, direction: prev.direction === "asc" ? "desc" : "asc" }
-        : { key, direction: "asc" }
+    groups.forEach((list) =>
+      list.sort((a, b) => a.course_code.localeCompare(b.course_code))
     );
-  };
+    return groups;
+  }, [filteredPlan]);
 
-  const openDialog = (code) => {
+  const termKeys = useMemo(() => {
+    const keys = Array.from(groupedPlan.keys());
+    return keys.sort((a, b) => {
+      const ai = termOrder.indexOf(a);
+      const bi = termOrder.indexOf(b);
+      if (ai === -1 && bi === -1) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  }, [groupedPlan]);
+
+  const requirementProgress = useMemo(() => {
+    return (programPlan?.requirements || []).map((group, idx) => {
+      const description = group.description || `Requirement ${idx + 1}`;
+      const options = (group.options || []).map((code) => {
+        const entry = plan.find((item) => item.course_code === code);
+        return {
+          code,
+          planned: Boolean(entry),
+          completed: Boolean(entry?.completed),
+        };
+      });
+      const status = options.some((opt) => opt.completed)
+        ? "complete"
+        : options.some((opt) => opt.planned)
+        ? "in-progress"
+        : "missing";
+      return { description, options, status };
+    });
+  }, [plan, programPlan]);
+
+  const requirementSummary = useMemo(() => {
+    return requirementProgress.reduce(
+      (acc, group) => {
+        acc[group.status] += 1;
+        return acc;
+      },
+      { complete: 0, "in-progress": 0, missing: 0 }
+    );
+  }, [requirementProgress]);
+
+  const openDialog = useCallback((code) => {
     setSelectedCode(code);
     setDialogOpen(true);
-  };
-  const closeDialog = () => {
+  }, []);
+
+  const closeDialog = useCallback(() => {
     setSelectedCode(null);
     setDialogOpen(false);
-  };
-  const selectedCourse = selectedCode ? coursesMap[selectedCode] : {};
+  }, []);
+
+  const selectedCourse = selectedCode ? coursesMap[selectedCode] : null;
+  const selectedPlanEntry = useMemo(
+    () => plan.find((item) => item.course_code === selectedCode),
+    [plan, selectedCode]
+  );
+
+  const handleTermChange = useCallback(
+    (code, value) => {
+      if (!onUpdateCourseTerm) return;
+      const entryExists = plan.some((item) => item.course_code === code);
+      if (!entryExists) return;
+      const normalized = value === fallbackTerm ? null : value;
+      onUpdateCourseTerm(code, normalized);
+    },
+    [onUpdateCourseTerm, plan]
+  );
+
+  const handleExport = useCallback(() => {
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      plan: plan.map((entry) => ({
+        course_code: entry.course_code,
+        term: entry.term,
+        completed: entry.completed,
+        title: coursesMap[entry.course_code]?.title || null,
+      })),
+      programPlan: programPlan || null,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `uw-course-plan-${new Date()
+      .toISOString()
+      .slice(0, 10)}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [coursesMap, plan, programPlan]);
 
   return (
-    <Box>
-      <Box sx={{ display: "flex", gap: 2, mb: 2, flexWrap: "wrap" }}>
-        <TextField
-          label="Search"
-          size="small"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          sx={{ flexGrow: 1, minWidth: 200 }}
-        />
-        <FormControl size="small" sx={{ minWidth: 180 }}>
-          <InputLabel>Subject</InputLabel>
-          <Select
-            multiple
-            value={subjects}
-            onChange={(e) => setSubjects(e.target.value)}
-            input={<OutlinedInput label="Subject" />}
-            renderValue={(sel) => (
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                {sel.map((s) => (
-                  <Chip key={s} label={s} size="small" />
-                ))}
-              </Box>
-            )}
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Paper
+        variant="outlined"
+        sx={{
+          p: { xs: 2.5, md: 3 },
+          borderRadius: 3,
+          background: (theme) =>
+            theme.palette.mode === "light"
+              ? "linear-gradient(140deg, rgba(0,93,170,0.1), rgba(255,184,0,0.08))"
+              : "linear-gradient(140deg, rgba(30,64,175,0.4), rgba(14,116,144,0.3))",
+        }}
+      >
+        <Stack spacing={3}>
+          <Stack
+            direction={{ xs: "column", md: "row" }}
+            spacing={3}
+            alignItems={{ xs: "flex-start", md: "center" }}
+            justifyContent="space-between"
           >
-            {allSubjects.map((s) => (
-              <MenuItem key={s} value={s}>
-                <MuiCheckbox checked={subjects.includes(s)} /> {s}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </Box>
+            <Box>
+              <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                Planner overview
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Track required courses, mark completions, and visualize progress
+                toward graduation.
+              </Typography>
+            </Box>
 
-      <TableContainer component={Paper} variant="outlined">
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              {["code", "title", "term", "completed"].map((col) => (
-                <TableCell key={col}>
-                  <TableSortLabel
-                    active={sortConfig.key === col}
-                    direction={sortConfig.direction}
-                    onClick={() => handleSort(col)}
-                  >
-                    {col.charAt(0).toUpperCase() + col.slice(1)}
-                  </TableSortLabel>
-                </TableCell>
-              ))}
-              <TableCell>Info</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {sorted.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} align="center">
-                  No rows
-                </TableCell>
-              </TableRow>
-            ) : (
-              sorted.map((item) => {
-                const code = item.course_code;
-                const course = coursesMap[code] || {};
-                return (
-                  <TableRow key={code}>
-                    <TableCell>{code}</TableCell>
-                    <TableCell>{course.title || "-"}</TableCell>
-                    <TableCell>{item.term}</TableCell>
-                    <TableCell>
-                      <Checkbox
+            <Stack
+              direction={{ xs: "column", lg: "row" }}
+              spacing={2.5}
+              alignItems={{ xs: "flex-start", lg: "center" }}
+            >
+              <Stack direction="row" spacing={4} flexWrap="wrap">
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Completed
+                  </Typography>
+                  <Typography variant="h4" sx={{ fontWeight: 700 }}>
+                    {progress.completed}
+                  </Typography>
+                </Box>
+                <Divider
+                  orientation="vertical"
+                  flexItem
+                  sx={{ display: { xs: "none", md: "block" } }}
+                />
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Remaining
+                  </Typography>
+                  <Typography variant="h4" sx={{ fontWeight: 700 }}>
+                    {progress.planned}
+                  </Typography>
+                </Box>
+                <Divider
+                  orientation="vertical"
+                  flexItem
+                  sx={{ display: { xs: "none", md: "block" } }}
+                />
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    Total courses
+                  </Typography>
+                  <Typography variant="h4" sx={{ fontWeight: 700 }}>
+                    {progress.total}
+                  </Typography>
+                </Box>
+              </Stack>
+              <Tooltip title="Download this plan as a JSON file for backups or advising">
+                <Button
+                  variant="outlined"
+                  color="secondary"
+                  startIcon={<DownloadIcon />}
+                  onClick={handleExport}
+                >
+                  Export plan
+                </Button>
+              </Tooltip>
+            </Stack>
+          </Stack>
+
+          <Box>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ minWidth: 100 }}>
+                Completion
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={progress.percentage}
+                sx={{ flexGrow: 1, height: 8, borderRadius: 5 }}
+              />
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                {progress.percentage}%
+              </Typography>
+            </Stack>
+          </Box>
+        </Stack>
+      </Paper>
+
+      {requirementProgress.length > 0 && (
+        <Paper variant="outlined" sx={{ p: { xs: 2.5, md: 3 }, borderRadius: 3 }}>
+          <Stack spacing={2.5}>
+            <Stack
+              direction={{ xs: "column", md: "row" }}
+              justifyContent="space-between"
+              spacing={2}
+              alignItems={{ xs: "flex-start", md: "center" }}
+            >
+              <Box>
+                <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                  Requirement tracker
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  See how your current plan covers each program requirement and
+                  identify any remaining gaps.
+                </Typography>
+              </Box>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                {Object.keys(requirementStatusConfig).map((key) => (
+                  <Chip
+                    key={key}
+                    size="small"
+                    color={requirementStatusConfig[key].color}
+                    variant="outlined"
+                    label={`${requirementStatusConfig[key].label}: ${
+                      requirementSummary[key]
+                    }`}
+                  />
+                ))}
+              </Stack>
+            </Stack>
+
+            <Stack spacing={2.5}>
+              {requirementProgress.map((group, idx) => (
+                <Paper
+                  key={`${group.description}-${idx}`}
+                  variant="outlined"
+                  sx={{
+                    borderRadius: 2,
+                    p: { xs: 2, md: 2.5 },
+                    backgroundColor: (theme) =>
+                      group.status === "complete"
+                        ? theme.palette.mode === "light"
+                          ? "rgba(16,185,129,0.08)"
+                          : "rgba(34,197,94,0.15)"
+                        : group.status === "in-progress"
+                        ? theme.palette.mode === "light"
+                          ? "rgba(59,130,246,0.08)"
+                          : "rgba(96,165,250,0.12)"
+                        : undefined,
+                  }}
+                >
+                  <Stack spacing={1.5}>
+                    <Stack
+                      direction={{ xs: "column", sm: "row" }}
+                      justifyContent="space-between"
+                      spacing={1.5}
+                      alignItems={{ xs: "flex-start", sm: "center" }}
+                    >
+                      <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                        {group.description}
+                      </Typography>
+                      <Chip
                         size="small"
-                        checked={!!item.completed}
-                        onChange={() => onToggleComplete(code)}
+                        color={requirementStatusConfig[group.status].color}
+                        label={requirementStatusConfig[group.status].label}
                       />
-                    </TableCell>
-                    <TableCell>
-                      <IconButton size="small" onClick={() => openDialog(code)}>
-                        <InfoIcon fontSize="small" />
-                      </IconButton>
-                    </TableCell>
-                    <TableCell>
-                      <IconButton
-                        size="small"
-                        onClick={() => onRemoveCourse(code)}
+                    </Stack>
+                    <Typography variant="caption" color="text.secondary">
+                      {group.options.length > 1
+                        ? "Complete any one of the following options:"
+                        : "This course must appear in your plan."}
+                    </Typography>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
+                      {group.options.map((option) => (
+                        <Chip
+                          key={option.code}
+                          label={option.code}
+                          color={
+                            option.completed
+                              ? "success"
+                              : option.planned
+                              ? "info"
+                              : "default"
+                          }
+                          variant={option.planned || option.completed ? "filled" : "outlined"}
+                          onClick={() => openDialog(option.code)}
+                          sx={{ cursor: "pointer" }}
+                        />
+                      ))}
+                    </Stack>
+                  </Stack>
+                </Paper>
+              ))}
+            </Stack>
+          </Stack>
+        </Paper>
+      )}
+
+      <Paper variant="outlined" sx={{ p: { xs: 2, md: 3 }, borderRadius: 3 }}>
+        <Stack
+          direction={{ xs: "column", xl: "row" }}
+          spacing={2}
+          alignItems={{ xs: "stretch", xl: "center" }}
+          flexWrap="wrap"
+        >
+          <TextField
+            label="Search plan"
+            size="small"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            sx={{ minWidth: { xs: "100%", sm: 220 }, flexGrow: 1 }}
+          />
+          <FormControl sx={{ minWidth: 200 }} size="small">
+            <InputLabel>Subject</InputLabel>
+            <Select
+              multiple
+              value={subjects}
+              onChange={(e) => setSubjects(e.target.value)}
+              input={<OutlinedInput label="Subject" />}
+              renderValue={(sel) => (
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                  {sel.map((s) => (
+                    <Chip key={s} label={s} size="small" />
+                  ))}
+                </Box>
+              )}
+            >
+              {allSubjects.map((subj) => (
+                <MenuItem key={subj} value={subj}>
+                  <Checkbox checked={subjects.includes(subj)} />
+                  <Typography sx={{ ml: 1 }}>{subj}</Typography>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl sx={{ minWidth: 200 }} size="small">
+            <InputLabel>Status</InputLabel>
+            <Select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              input={<OutlinedInput label="Status" />}
+            >
+              <MenuItem value="all">All courses</MenuItem>
+              <MenuItem value="complete">Completed only</MenuItem>
+              <MenuItem value="incomplete">Still planned</MenuItem>
+            </Select>
+          </FormControl>
+          {(search || subjects.length || statusFilter !== "all") && (
+            <Button
+              color="secondary"
+              onClick={() => {
+                setSearch("");
+                setSubjects([]);
+                setStatusFilter("all");
+              }}
+            >
+              Clear filters
+            </Button>
+          )}
+        </Stack>
+      </Paper>
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: {
+            xs: "1fr",
+            md: "repeat(auto-fit, minmax(280px, 1fr))",
+          },
+          gap: 3,
+        }}
+      >
+        {termKeys.map((term) => {
+          const courses = groupedPlan.get(term) || [];
+          return (
+            <Paper
+              key={term}
+              variant="outlined"
+              sx={{
+                borderRadius: 3,
+                overflow: "hidden",
+                display: "flex",
+                flexDirection: "column",
+                minHeight: 200,
+              }}
+            >
+              <Box
+                sx={{
+                  px: 2.5,
+                  py: 2,
+                  bgcolor: (theme) =>
+                    theme.palette.mode === "light"
+                      ? "rgba(0,93,170,0.08)"
+                      : "rgba(30,64,175,0.35)",
+                  borderBottom: (theme) =>
+                    `1px solid ${
+                      theme.palette.mode === "light"
+                        ? "rgba(148, 163, 184, 0.3)"
+                        : "rgba(71, 85, 105, 0.6)"
+                    }`,
+                }}
+              >
+                <Stack direction="row" alignItems="center" justifyContent="space-between">
+                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                    {term}
+                  </Typography>
+                  <Chip
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    label={`${courses.length} course${courses.length === 1 ? "" : "s"}`}
+                  />
+                </Stack>
+              </Box>
+
+              <Stack spacing={2} sx={{ p: 2.5 }}>
+                {courses.length === 0 ? (
+                  <Typography color="text.secondary" variant="body2">
+                    No courses scheduled for this term.
+                  </Typography>
+                ) : (
+                  courses.map((item) => {
+                    const code = item.course_code;
+                    const course = coursesMap[code] || {};
+                    const isRequired = requiredSet.has(code);
+                    return (
+                  <Paper
+                    key={code}
+                    variant="outlined"
+                    sx={{
+                      p: 2,
+                          borderRadius: 2,
+                          position: "relative",
+                          borderColor: item.completed
+                            ? (theme) => theme.palette.success.main
+                            : undefined,
+                          backgroundColor: (theme) => {
+                            if (item.completed) {
+                              return theme.palette.mode === "light"
+                                ? "rgba(46, 204, 113, 0.08)"
+                                : "rgba(34, 197, 94, 0.15)";
+                            }
+                            return theme.palette.mode === "light"
+                              ? "rgba(255,255,255,0.9)"
+                              : theme.palette.background.paper;
+                          },
+                        }}
                       >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
+                        <Stack spacing={1.5}>
+                          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                            <Box>
+                              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                                {code}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {course.title || "Title not available"}
+                              </Typography>
+                            </Box>
+                            <Stack direction="row" spacing={1} alignItems="center">
+                              {isRequired && <Chip color="secondary" size="small" label="Required" />}
+                            </Stack>
+                          </Stack>
+                          {course.requirementsDescription && (
+                            <Typography variant="caption" color="text.secondary">
+                              Prerequisites: {course.requirementsDescription}
+                            </Typography>
+                          )}
+                          <FormControl size="small" sx={{ minWidth: 160 }}>
+                            <InputLabel>Term</InputLabel>
+                            <Select
+                              label="Term"
+                              value={item.term || fallbackTerm}
+                              onChange={(e) => handleTermChange(code, e.target.value)}
+                            >
+                              {termOptions.map((term) => (
+                                <MenuItem key={term} value={term}>
+                                  {term === fallbackTerm ? "Unassigned" : term}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </FormControl>
+                          <Stack direction="row" spacing={1} justifyContent="flex-end">
+                            <Tooltip
+                              title={item.completed ? "Mark as incomplete" : "Mark as completed"}
+                            >
+                              <IconButton
+                                size="small"
+                                color={item.completed ? "success" : "default"}
+                                onClick={() => onToggleComplete(code)}
+                              >
+                                {item.completed ? (
+                                  <CheckCircleIcon fontSize="small" />
+                                ) : (
+                                  <RadioButtonUncheckedIcon fontSize="small" />
+                                )}
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="View details">
+                              <IconButton size="small" onClick={() => openDialog(code)}>
+                                <InfoIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Remove from plan">
+                              <IconButton
+                                size="small"
+                                color="error"
+                                onClick={() => onRemoveCourse(code)}
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          </Stack>
+                        </Stack>
+                      </Paper>
+                    );
+                  })
+                )}
+              </Stack>
+            </Paper>
+          );
+        })}
+        {termKeys.length === 0 && (
+          <Paper
+            variant="outlined"
+            sx={{
+              borderRadius: 3,
+              p: { xs: 3, md: 4 },
+            }}
+          >
+            <Typography variant="h6" gutterBottom>
+              No courses in your plan yet
+            </Typography>
+            <Typography color="text.secondary">
+              Search the course catalog and add classes to build your personalized
+              roadmap.
+            </Typography>
+          </Paper>
+        )}
+      </Box>
 
       <Dialog open={dialogOpen} onClose={closeDialog} fullWidth maxWidth="sm">
         <DialogTitle>
-          {selectedCode} — {selectedCourse?.title}
-          <IconButton
-            onClick={closeDialog}
-            sx={{ position: "absolute", right: 8, top: 8 }}
-          >
-            <CloseIcon />
-          </IconButton>
+          {selectedCode} — {selectedCourse?.title || "Course information"}
         </DialogTitle>
         <DialogContent dividers>
-          {selectedCourse?.description ? (
-            <Typography paragraph>{selectedCourse.description}</Typography>
-          ) : (
-            <Typography color="text.secondary">
-              No description available.
-            </Typography>
+          <Typography variant="subtitle1" gutterBottom>
+            Description
+          </Typography>
+          <Typography variant="body2" paragraph>
+            {selectedCourse?.description || "No description available."}
+          </Typography>
+          {selectedCourse?.requirementsDescription && (
+            <>
+              <Typography variant="subtitle1" gutterBottom>
+                Prerequisites
+              </Typography>
+              <Typography variant="body2">
+                {selectedCourse.requirementsDescription}
+              </Typography>
+            </>
           )}
+          {!selectedPlanEntry && (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              Add this course from the catalog to schedule it in a term.
+            </Alert>
+          )}
+          <Box mt={3}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Term assignment</InputLabel>
+              <Select
+                label="Term assignment"
+                value={selectedPlanEntry?.term || fallbackTerm}
+                onChange={(e) => handleTermChange(selectedCode, e.target.value)}
+                disabled={!selectedPlanEntry}
+              >
+                {termOptions.map((term) => (
+                  <MenuItem key={term} value={term}>
+                    {term === fallbackTerm ? "Unassigned" : term}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
         </DialogContent>
         <DialogActions>
           <Button onClick={closeDialog}>Close</Button>


### PR DESCRIPTION
## Summary
- add backend updates to support term changes directly from the planner UI
- introduce a requirement tracker with status chips and quick links to satisfy missing program requirements
- enable JSON plan exports and richer course dialogs that guide scheduling actions

## Testing
- npm test -- --watchAll=false *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d586460f58832aa49a1b8935cfce14