### PR TITLE
Improve catalog sidebar layout and persist custom plans

### DIFF
--- a/client/src/utils/programPlan.js
+++ b/client/src/utils/programPlan.js
@@ -1,0 +1,48 @@
+import compMathPlan from "../data/comp_math_plan.json";
+
+export const DEFAULT_PLAN_NAME = "Computational Mathematics";
+export const DEFAULT_SUBJECTS = ["MATH", "AMATH", "CO", "CS", "PMATH", "STAT"];
+
+export function normalizePlan(rawPlan = {}) {
+  const requirements = Array.isArray(rawPlan.requirements)
+    ? rawPlan.requirements
+        .map((req) => {
+          const description =
+            typeof req?.description === "string" && req.description.trim()
+              ? req.description.trim()
+              : null;
+          const options = Array.isArray(req?.options)
+            ? req.options
+                .map((code) =>
+                  typeof code === "string" && code.trim() ? code.trim() : null
+                )
+                .filter(Boolean)
+            : [];
+          if (!description && options.length === 0) return null;
+          return {
+            description: description || options.join(", "),
+            options,
+          };
+        })
+        .filter(Boolean)
+    : [];
+
+  const relevantSubjects = Array.isArray(rawPlan.relevantSubjects)
+    ? rawPlan.relevantSubjects
+        .map((subj) =>
+          typeof subj === "string" && subj.trim() ? subj.trim().toUpperCase() : null
+        )
+        .filter(Boolean)
+    : [];
+
+  return {
+    name:
+      (typeof rawPlan.name === "string" && rawPlan.name.trim()) ||
+      DEFAULT_PLAN_NAME,
+    relevantSubjects:
+      relevantSubjects.length > 0 ? relevantSubjects : DEFAULT_SUBJECTS,
+    requirements,
+  };
+}
+
+export const DEFAULT_PLAN = normalizePlan(compMathPlan);

--- a/supabase/migrations/20241205120000_create_user_program_plans.sql
+++ b/supabase/migrations/20241205120000_create_user_program_plans.sql
@@ -1,0 +1,23 @@
+create table if not exists public.user_program_plans (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  plan jsonb not null,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_program_plans enable row level security;
+
+create policy if not exists "Users can view own program plan"
+  on public.user_program_plans
+  for select
+  using (auth.uid() = user_id);
+
+create policy if not exists "Users can insert own program plan"
+  on public.user_program_plans
+  for insert
+  with check (auth.uid() = user_id);
+
+create policy if not exists "Users can update own program plan"
+  on public.user_program_plans
+  for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- restyled the catalog sidebar to use a sticky paper layout that scales cleanly across screen sizes
- shared plan normalization helpers and wired the catalog to save/reset custom requirement plans through Supabase
- added a Supabase migration for the per-user program plan table and policies

## Testing
- npm test -- --watchAll=false *(fails: Missing Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b2c22864832a97bad620b3943add