### PR TITLE
Refine global styling with cohesive background

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -68,28 +68,45 @@ function App() {
       },
     });
 
-    const surfaceGradient = `linear-gradient(140deg, ${alpha(
+    const backgroundToneTop = alpha(
+      baseTheme.palette.primary.light,
+      darkMode ? 0.26 : 0.16
+    );
+    const backgroundToneCorner = alpha(
+      baseTheme.palette.secondary.light,
+      darkMode ? 0.24 : 0.12
+    );
+    const canvasTop = alpha(
+      baseTheme.palette.background.default,
+      1
+    );
+    const canvasBottom = alpha(
       baseTheme.palette.background.paper,
-      darkMode ? 0.32 : 0.82
-    )} 0%, ${alpha(
-      baseTheme.palette.background.paper,
-      darkMode ? 0.15 : 0.62
-    )} 100%)`;
-    const surfaceBorder = `1px solid ${alpha(
-      darkMode ? baseTheme.palette.common.white : baseTheme.palette.common.black,
-      darkMode ? 0.1 : 0.12
-    )}`;
-    const floatingShadow = `0 32px 80px ${alpha(
-      baseTheme.palette.common.black,
-      darkMode ? 0.6 : 0.18
-    )}`;
+      darkMode ? 0.92 : 0.98
+    );
 
-    const floatingSurface = {
+    const siteBackground = [
+      `radial-gradient(120% 120% at 0% 0%, ${backgroundToneTop} 0%, transparent 65%)`,
+      `radial-gradient(120% 120% at 100% 0%, ${backgroundToneCorner} 0%, transparent 70%)`,
+      `linear-gradient(180deg, ${canvasTop} 0%, ${canvasBottom} 100%)`,
+    ].join(",");
+
+    const surfaceBorderColor = alpha(
+      baseTheme.palette.divider,
+      darkMode ? 0.7 : 0.4
+    );
+    const surfaceShadow = darkMode
+      ? "0 18px 45px rgba(2, 6, 23, 0.55)"
+      : "0 20px 38px rgba(15, 23, 42, 0.12)";
+
+    const elevatedSurface = {
+      backgroundColor: alpha(
+        baseTheme.palette.background.paper,
+        darkMode ? 0.85 : 1
+      ),
       backgroundImage: "none",
-      background: surfaceGradient,
-      border: surfaceBorder,
-      backdropFilter: "blur(24px)",
-      boxShadow: floatingShadow,
+      border: `1px solid ${surfaceBorderColor}`,
+      boxShadow: surfaceShadow,
     };
 
     return createTheme(baseTheme, {
@@ -100,45 +117,9 @@ function App() {
               minHeight: "100vh",
               position: "relative",
               backgroundAttachment: "fixed",
-              background: `radial-gradient(120% 120% at 0% 0%, ${alpha(
-                baseTheme.palette.primary.main,
-                darkMode ? 0.24 : 0.16
-              )} 0%, transparent 60%), radial-gradient(110% 110% at 100% 0%, ${alpha(
-                baseTheme.palette.secondary.main,
-                darkMode ? 0.22 : 0.14
-              )} 0%, transparent 62%), linear-gradient(180deg, ${alpha(
-                baseTheme.palette.background.default,
-                1
-              )} 0%, ${alpha(
-                baseTheme.palette.background.paper,
-                darkMode ? 0.95 : 0.9
-              )} 100%)`,
-            },
-            "&::before": {
-              content: '""',
-              position: "fixed",
-              inset: "-35% -15%",
-              pointerEvents: "none",
-              background: `radial-gradient(70% 70% at 45% 10%, ${alpha(
-                baseTheme.palette.primary.light,
-                darkMode ? 0.28 : 0.24
-              )} 0%, transparent 65%)`,
-              filter: "blur(120px)",
-              opacity: darkMode ? 0.7 : 0.55,
-              zIndex: -1,
-            },
-            "&::after": {
-              content: '""',
-              position: "fixed",
-              inset: "-30% -20%",
-              pointerEvents: "none",
-              background: `radial-gradient(65% 65% at 80% 85%, ${alpha(
-                baseTheme.palette.secondary.light,
-                darkMode ? 0.3 : 0.22
-              )} 0%, transparent 70%)`,
-              filter: "blur(120px)",
-              opacity: darkMode ? 0.65 : 0.5,
-              zIndex: -1,
+              backgroundImage: siteBackground,
+              backgroundColor: canvasTop,
+              backgroundSize: "cover",
             },
             "*, *::before, *::after": {
               boxSizing: "border-box",
@@ -154,47 +135,47 @@ function App() {
         },
         MuiPaper: {
           styleOverrides: {
-            root: floatingSurface,
+            root: elevatedSurface,
           },
         },
         MuiAppBar: {
           styleOverrides: {
             root: {
-              ...floatingSurface,
+              ...elevatedSurface,
               borderRadius: 28,
-              boxShadow: `0 28px 70px ${alpha(
-                baseTheme.palette.common.black,
-                darkMode ? 0.55 : 0.2
-              )}`,
+              boxShadow: darkMode
+                ? "0 20px 48px rgba(2, 6, 23, 0.6)"
+                : "0 24px 50px rgba(15, 23, 42, 0.14)",
+              color: baseTheme.palette.text.primary,
             },
           },
         },
         MuiMenu: {
           styleOverrides: {
-            paper: floatingSurface,
+            paper: elevatedSurface,
           },
         },
         MuiPopover: {
           styleOverrides: {
-            paper: floatingSurface,
+            paper: elevatedSurface,
           },
         },
         MuiDialog: {
           styleOverrides: {
             paper: {
-              ...floatingSurface,
+              ...elevatedSurface,
               borderRadius: 24,
             },
           },
         },
         MuiCard: {
           styleOverrides: {
-            root: floatingSurface,
+            root: elevatedSurface,
           },
         },
         MuiTableContainer: {
           styleOverrides: {
-            root: floatingSurface,
+            root: elevatedSurface,
           },
         },
         MuiTooltip: {

--- a/client/src/components/InfoHub.js
+++ b/client/src/components/InfoHub.js
@@ -54,49 +54,27 @@ const requirementExample = JSON.stringify(
   2
 );
 
-const glassPanel = (theme) => ({
-  position: "relative",
-  overflow: "hidden",
-  borderRadius: 3,
-  backdropFilter: "blur(20px)",
-  background: `linear-gradient(145deg, ${alpha(
-    theme.palette.background.paper,
-    0.2
-  )}, ${alpha(theme.palette.background.paper, 0.05)})`,
-  border: `1px solid ${alpha(theme.palette.common.white, 0.14)}`,
-  boxShadow: `0 24px 70px ${alpha(theme.palette.common.black, 0.2)}`,
-  "&::before": {
-    content: '""',
-    position: "absolute",
-    inset: -20,
-    borderRadius: "inherit",
-    background: `radial-gradient(60% 60% at 20% 20%, ${alpha(
-      theme.palette.primary.main,
-      0.18
-    )} 0%, transparent 70%)`,
-    opacity: 0.7,
-    filter: "blur(50px)",
-  },
-  "&::after": {
-    content: '""',
-    position: "absolute",
-    inset: 0,
-    borderRadius: "inherit",
-    background: `linear-gradient(160deg, ${alpha(
-      theme.palette.common.white,
-      0.18
-    )} 0%, transparent 55%)`,
-    mixBlendMode: "screen",
-    pointerEvents: "none",
-  },
-});
+const cardPanel = (theme) => {
+  const isDark = theme.palette.mode === "dark";
+  return {
+    position: "relative",
+    overflow: "hidden",
+    borderRadius: 3,
+    backgroundColor: alpha(
+      theme.palette.background.paper,
+      isDark ? 0.86 : 1
+    ),
+    border: `1px solid ${alpha(theme.palette.divider, isDark ? 0.7 : 0.45)}`,
+    boxShadow: theme.shadows[4],
+  };
+};
 
 export default function InfoHub() {
   return (
     <Stack spacing={4} sx={{ pb: 4, flex: 1, minHeight: 0 }}>
       <Paper
         elevation={0}
-        sx={[(theme) => glassPanel(theme), { px: { xs: 3, md: 5 }, py: { xs: 4, md: 6 }, borderRadius: 4 }]}
+        sx={[(theme) => cardPanel(theme), { px: { xs: 3, md: 5 }, py: { xs: 4, md: 6 }, borderRadius: 4 }]}
       >
         <Stack spacing={2} sx={{ maxWidth: 720 }}>
           <Chip
@@ -122,7 +100,7 @@ export default function InfoHub() {
         <Grid item xs={12} md={6}>
           <Paper
             elevation={0}
-            sx={[(theme) => glassPanel(theme), { height: "100%", p: 3, display: "flex", flexDirection: "column", gap: 2 }]}
+            sx={[(theme) => cardPanel(theme), { height: "100%", p: 3, display: "flex", flexDirection: "column", gap: 2 }]}
           >
             <Stack direction="row" spacing={2} alignItems="center">
               <SchemaIcon color="primary" />
@@ -168,7 +146,7 @@ export default function InfoHub() {
         <Grid item xs={12} md={6}>
           <Paper
             elevation={0}
-            sx={[(theme) => glassPanel(theme), { height: "100%", p: 3, display: "flex", flexDirection: "column", gap: 2 }]}
+            sx={[(theme) => cardPanel(theme), { height: "100%", p: 3, display: "flex", flexDirection: "column", gap: 2 }]}
           >
             <Stack direction="row" spacing={2} alignItems="center">
               <CodeIcon color="primary" />
@@ -193,15 +171,17 @@ export default function InfoHub() {
                 fontFamily: "'Source Code Pro', 'Fira Code', monospace",
                 fontSize: 13,
                 color: "text.primary",
-                background: (theme) =>
-                  `linear-gradient(135deg, ${alpha(
-                    theme.palette.background.paper,
-                    0.6
-                  )}, ${alpha(theme.palette.background.paper, 0.4)})`,
+                backgroundColor: (theme) =>
+                  alpha(
+                    theme.palette.background.default,
+                    theme.palette.mode === "dark" ? 0.55 : 0.92
+                  ),
                 border: (theme) =>
-                  `1px solid ${alpha(theme.palette.common.white, 0.18)}`,
-                boxShadow: (theme) =>
-                  `0 18px 35px ${alpha(theme.palette.common.black, 0.15)}`,
+                  `1px solid ${alpha(
+                    theme.palette.divider,
+                    theme.palette.mode === "dark" ? 0.7 : 0.5
+                  )}`,
+                boxShadow: (theme) => theme.shadows[2],
               }}
             >
               {samplePlan}
@@ -212,7 +192,7 @@ export default function InfoHub() {
 
       <Paper
         elevation={0}
-        sx={[(theme) => glassPanel(theme), { p: { xs: 3, md: 4 }, display: "flex", flexDirection: "column", gap: 3 }]}
+        sx={[(theme) => cardPanel(theme), { p: { xs: 3, md: 4 }, display: "flex", flexDirection: "column", gap: 3 }]}
       >
         <Stack direction={{ xs: "column", md: "row" }} spacing={2} alignItems={{ md: "center" }}>
           <TipsIcon color="primary" />
@@ -236,14 +216,10 @@ export default function InfoHub() {
             fontFamily: "'Source Code Pro', 'Fira Code', monospace",
             fontSize: 13,
             color: "text.primary",
-            background: (theme) =>
-              `linear-gradient(135deg, ${alpha(
-                theme.palette.background.paper,
-                0.6
-              )}, ${alpha(theme.palette.background.paper, 0.4)})`,
-            border: (theme) => `1px solid ${alpha(theme.palette.common.white, 0.18)}`,
-            boxShadow: (theme) =>
-              `0 18px 35px ${alpha(theme.palette.common.black, 0.15)}`,
+            backgroundColor: (theme) =>
+              alpha(theme.palette.background.paper, 0.92),
+            border: (theme) => `1px solid ${alpha(theme.palette.divider, 0.6)}`,
+            boxShadow: (theme) => theme.shadows[2],
           }}
         >
           {requirementExample}
@@ -281,7 +257,7 @@ export default function InfoHub() {
 
       <Paper
         elevation={0}
-        sx={[(theme) => glassPanel(theme), { p: { xs: 3, md: 4 }, display: "flex", flexDirection: "column", gap: 2 }]}
+        sx={[(theme) => cardPanel(theme), { p: { xs: 3, md: 4 }, display: "flex", flexDirection: "column", gap: 2 }]}
       >
         <Typography variant="h6" sx={{ fontWeight: 600 }}>
           Workflow best practices


### PR DESCRIPTION
## Summary
- replace the sitewide glassmorphism overrides with grounded card surfaces
- apply a balanced gradient background to the entire app
- align InfoHub cards and sample code block with the updated surfaces

## Testing
- `npm test -- --watchAll=false` *(fails: Missing Supabase env vars. Please define REACT_APP_SUPABASE_URL and REACT_APP_SUPABASE_ANON_KEY.)*

------
https://chatgpt.com/codex/tasks/task_e_68d6052a2abc832a82143d66d7cd34fa