### PR TITLE
Add scheduled course sync and preload catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ UW Course Planner is a web application for University of Waterloo students to se
 
 After installation, you may need to populate the `courses` table by invoking the `fetch-courses` function. This is done automatically on Supabase start; it fetches current term courses from the UW Open Data API and upserts them into the database (using the defined program requirements).
 
+## Automated catalog refresh
+
+- The Supabase project is configured with a cron job (`supabase/config.toml`) that triggers the `fetch-courses` edge function every day at 05:30 UTC. The job calls the function with the service role key so the catalog stays synchronized without manual intervention.
+- Make sure the `SUPABASE_SERVICE_ROLE_KEY` secret is available to the project (for local development set it in your environment before running `supabase start`).
+- When you deploy the infrastructure, run `supabase cron deploy` so the scheduled job is registered with your Supabase project.
+
 ## Usage
 
 1. **Open the app:** Navigate to `http://localhost:3000` in your browser.  

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -101,6 +101,14 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
+[cron]
+enabled = true
+
+[[cron.jobs]]
+name = "refresh-courses"
+schedule = "30 5 * * *"
+command = "bash -lc 'curl --fail --silent --show-error --request POST \"$SUPABASE_URL/functions/v1/fetch-courses\" --header \"Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY\"'"
+
 [auth]
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used


### PR DESCRIPTION
## Summary
- load the course catalog as soon as the app mounts so it is available before users sign in
- guard plan loading logic so it resets cleanly on logout and avoids updating state after unmount
- configure a Supabase cron job and docs so the fetch-courses function runs every morning automatically

## Testing
- npm test -- --watchAll=false *(fails: Missing Supabase env vars. Please define REACT_APP_SUPABASE_URL and REACT_APP_SUPABASE_ANON_KEY.)*

------
https://chatgpt.com/codex/tasks/task_e_68d6300a979c832a8ea78309903c6d7d