### PR TITLE
Adjust app bar height and reset default plan

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -750,7 +750,10 @@ function App() {
               color: (theme) => theme.palette.text.primary,
             }}
           >
-            <Toolbar disableGutters sx={{ minHeight: 72 }}>
+          <Toolbar
+            disableGutters
+            sx={{ minHeight: 64, height: 64, alignItems: "center" }}
+          >
             <Container
               maxWidth="xl"
               sx={{

--- a/client/src/utils/programPlan.js
+++ b/client/src/utils/programPlan.js
@@ -1,7 +1,4 @@
-import compMathPlan from "../data/comp_math_plan.json";
-
-export const DEFAULT_PLAN_NAME = "Computational Mathematics";
-export const DEFAULT_SUBJECTS = ["MATH", "AMATH", "CO", "CS", "PMATH", "STAT"];
+export const DEFAULT_PLAN_NAME = "Custom Plan";
 
 export function normalizePlan(rawPlan = {}) {
   const requirements = Array.isArray(rawPlan.requirements)
@@ -39,10 +36,13 @@ export function normalizePlan(rawPlan = {}) {
     name:
       (typeof rawPlan.name === "string" && rawPlan.name.trim()) ||
       DEFAULT_PLAN_NAME,
-    relevantSubjects:
-      relevantSubjects.length > 0 ? relevantSubjects : DEFAULT_SUBJECTS,
+    relevantSubjects,
     requirements,
   };
 }
 
-export const DEFAULT_PLAN = normalizePlan(compMathPlan);
+export const DEFAULT_PLAN = normalizePlan({
+  name: DEFAULT_PLAN_NAME,
+  relevantSubjects: [],
+  requirements: [],
+});


### PR DESCRIPTION
## Summary
- align the app bar toolbar with the web design by enforcing a 64px height
- remove the baked-in Computational Mathematics template so users start with a neutral plan

## Testing
- CI=true npm test -- --watchAll=false *(fails: Missing Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68d639a33438832a844b073ec89f8cf6